### PR TITLE
Update SqlUtil.java

### DIFF
--- a/src/main/java/com/github/pagehelper/util/SqlUtil.java
+++ b/src/main/java/com/github/pagehelper/util/SqlUtil.java
@@ -105,8 +105,8 @@ public class SqlUtil extends BaseSqlUtil implements Constant {
             lock.lock();
             try{
                 if(autoDialect){
-                    autoDialect = false;
                     this.dialect = getDialect(ms);
+                    autoDialect = false;//ensure dialect is set corrected
                 }
             }finally {
                 lock.unlock();


### PR DESCRIPTION
数据源无法建立链接时，更新了autoDialect会导致后续的空指针，后续连接恢复后也无法恢复。