### PR TITLE
fix pageNum=0

### DIFF
--- a/src/main/java/com/github/pagehelper/Page.java
+++ b/src/main/java/com/github/pagehelper/Page.java
@@ -198,7 +198,9 @@ public class Page<E> extends ArrayList<E> implements Closeable {
         }
         //分页合理化，针对不合理的页码自动处理
         if ((reasonable != null && reasonable) && pageNum > pages) {
-            pageNum = pages;
+            if(pages!=0){
+                pageNum = pages;
+            }
             calculateStartAndEndRow();
         }
     }


### PR DESCRIPTION
这部分代码会让PageNum=0

这是不正确的，因为PageNum在没有数据的情况下，也应该被合理化为1

当查不到数据时，pages=0，pageNum 会被赋值为0，然后导致最后pageNum一直为0

calculateStartAndEndRow() 会用pageNum进行计算，pageNum会影响这部分的计算。但是在其他位置会修正这个问题。

