### PR TITLE
#fix fix ci error,remove JDK 1.6 and 1.7 environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ dist: precise
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk6
 
 cache:
   directories:


### PR DESCRIPTION
fix ci error , mybaits 3.5 not support JDK 1.6 and 1.7  env 

[mybatis issue](https://github.com/mybatis/mybatis-3/issues/1207)