### PR TITLE
优化分页结果包装类的泛型参数

### DIFF
--- a/src/main/java/com/github/pagehelper/PageInfo.java
+++ b/src/main/java/com/github/pagehelper/PageInfo.java
@@ -120,7 +120,7 @@ public class PageInfo<T> extends PageSerializable<T> {
      *
      * @param list
      */
-    public PageInfo(List<T> list) {
+    public PageInfo(List<? extends T> list) {
         this(list, DEFAULT_NAVIGATE_PAGES);
     }
 
@@ -130,7 +130,7 @@ public class PageInfo<T> extends PageSerializable<T> {
      * @param list          page结果
      * @param navigatePages 页码数量
      */
-    public PageInfo(List<T> list, int navigatePages) {
+    public PageInfo(List<? extends T> list, int navigatePages) {
         super(list);
         if (list instanceof Page) {
             Page page = (Page) list;
@@ -162,11 +162,11 @@ public class PageInfo<T> extends PageSerializable<T> {
         }
     }
 
-    public static <T> PageInfo<T> of(List<T> list) {
+    public static <T> PageInfo<T> of(List<? extends T> list) {
         return new PageInfo<T>(list);
     }
 
-    public static <T> PageInfo<T> of(List<T> list, int navigatePages) {
+    public static <T> PageInfo<T> of(List<? extends T> list, int navigatePages) {
         return new PageInfo<T>(list, navigatePages);
     }
 

--- a/src/main/java/com/github/pagehelper/PageSerializable.java
+++ b/src/main/java/com/github/pagehelper/PageSerializable.java
@@ -40,16 +40,17 @@ public class PageSerializable<T> implements Serializable {
     public PageSerializable() {
     }
 
-    public PageSerializable(List<T> list) {
-        this.list = list;
+    @SuppressWarnings("unchecked")
+    public PageSerializable(List<? extends T> list) {
+        this.list = (List<T>) list;
         if(list instanceof Page){
-            this.total = ((Page)list).getTotal();
+            this.total = ((Page<?>)list).getTotal();
         } else {
             this.total = list.size();
         }
     }
 
-    public static <T> PageSerializable<T> of(List<T> list){
+    public static <T> PageSerializable<T> of(List<? extends T> list){
         return new PageSerializable<T>(list);
     }
 


### PR DESCRIPTION
在业务开发中，有时会使用BaseEntity作为实体基类；或为提升系统性能，划分出结构相似的临时表、正式表、历史表等不同的实体；或者提供只读的接口来安全缓存数据。

分页结果包装类作为泛型容器，可以支持存放具体类(concrete class) 并返回泛化类型，方便服务层编码。
