### PR TITLE
Update PageInterceptor.java

### DIFF
--- a/src/main/java/com/github/pagehelper/PageInterceptor.java
+++ b/src/main/java/com/github/pagehelper/PageInterceptor.java
@@ -157,7 +157,14 @@ public class PageInterceptor implements Interceptor {
     private Long count(Executor executor, MappedStatement ms, Object parameter,
                        RowBounds rowBounds, ResultHandler resultHandler,
                        BoundSql boundSql) throws SQLException {
-        String countMsId = ms.getId() + countSuffix;
+        String countMsId = ms.getId();
+        // fix:  手写sql对应_COUNT 保持不变
+        // fix:  selectByExamle对应selectCountByExample
+        if (countMsId.endsWith("selectByExample")){
+            countMsId = ms.getId().replaceAll("selectByExample$", "selectCountByExample");
+        }else{
+            countMsId = ms.getId() + countSuffix;
+        }
         Long count;
         //先判断是否存在手写的 count 查询
         MappedStatement countMs = ExecutorUtil.getExistedMappedStatement(ms.getConfiguration(), countMsId);


### PR DESCRIPTION
  // 没想到缓存作用这么大，我用的之后直接超时。
// 因为没有命中缓存，fix
```java
private Long count(Executor executor, MappedStatement ms, Object parameter,
                       RowBounds rowBounds, ResultHandler resultHandler,
                       BoundSql boundSql) throws SQLException {
        String countMsId = ms.getId() ;
        // fix:  手写sql对应_COUNT 保持不变
        // fix:  selectByExamle对应selectCountByExample
        if (countMsId.endsWith("selectByExample")){
            countMsId = ms.getId().replaceAll("selectByExample$", "selectCountByExample");
        }else{
            countMsId = ms.getId() + countSuffix;
        }
        Long count;
        // 先判断是否存在手写的 count 查询
        MappedStatement countMs = ExecutorUtil.getExistedMappedStatement(ms.getConfiguration(), countMsId);
        if (countMs != null) {
            count = ExecutorUtil.executeManualCount(executor, countMs, parameter, boundSql, resultHandler);
        } else {
            if (msCountMap != null) {
                countMs = msCountMap.get(countMsId);
            }
            // 自动创建
            if (countMs == null) {
                // 根据当前的 ms 创建一个返回值为 Long 类型的 ms
                countMs = MSUtils.newCountMappedStatement(ms, countMsId);
                if (msCountMap != null) {
                    msCountMap.put(countMsId, countMs);
                }
            }
            count = ExecutorUtil.executeAutoCount(this.dialect, executor, countMs, parameter, boundSql, rowBounds, resultHandler);
        }
        return count;
    }
```