### PR TITLE
oceanbase_support

### DIFF
--- a/src/main/java/com/github/pagehelper/page/PageAutoDialect.java
+++ b/src/main/java/com/github/pagehelper/page/PageAutoDialect.java
@@ -143,6 +143,9 @@ public class PageAutoDialect {
                 return dialect;
             }
         }
+        if (url.contains("oceanbase")){
+            return "mysql";
+        }
         return null;
     }
 


### PR DESCRIPTION
特别说明：  oceanbase数据库分为MySQL模式和Oracle模式，两种模式语法分别兼容原生Oracle/MySQL数据库，分别使用MySQL/Oracle的Dialect即可。MySQL模式数据库连接url为**jdbc:oceanbsae**://ip:port/databaseName，Oracle模式则有**jdbc:oceanbsae**://ip:port/databaseName 和 **jdbc:oceanbsae:oracle**//ip:port/databaseName两种，如果使用原有url.contains(":" + dialect.toLowerCase() + ":")进行判断则可能会引起混淆，我们会建议客户在使用pagehelper+oceanbase时，Oracle模式下url使用jdbc:oceanbase:oracle格式，这样可以在原有的url.contains(":" + dialect.toLowerCase() + ":")判断中命中Oracle并返回预期结果，因此fromUrlJdbc方法里只增加了contains("oceanbase") return "mysql"