### PR TITLE
Ignoring unnecessarily generated surefire-report

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,4 +13,4 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Run the Maven verify phase
-        run: mvn --batch-mode --update-snapshots -P dev verify
+        run: mvn --batch-mode --update-snapshots -P dev verify -Dsurefire.useFile=false -DdisableXmlReport=true


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding  -Dsurefire.useFile=false -DdisableXmlReport=true to the mvn command.