### PR TITLE
内嵌 jsqlparser 以规避版本冲突

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Maven #
 target/
+dependency-reduced-pom.xml
 
 # IDEA #
 .idea/

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,44 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.github.jsqlparser:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>net.sf.jsqlparser</pattern>
+                                    <shadedPattern>com.github.pagehelper.jsqlparser</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <profiles>
         <profile>


### PR DESCRIPTION
项目中有时会引用`jsqlparser`，但是由于`jsqlparser`各版本之间总是会有兼容性问题，经常会面临版本冲突的问题。
所以，我建议`pagehelper`将自己所使用的`jsqlparser`内嵌进 jar 包以规避此类问题。

`maven-shade-plugin`可以在打包时将所有对`net.sf.jsqlparser`的引用重定向到`com.github.pagehelper.jsqlparser`，这样这部份代码将只被`pagehelper`使用，而不影响外部项目。不管`pagehelper`使用什么版本的`jsqlparser`，外部项目使用什么版本的`jsqlparser`都不会互相干扰。同时`maven-shade-plugin`可以生成一个新的不包含对`jsqlparser`依赖的`pom.xml`，用于项目发布。