### PR TITLE
fix: 在复制countBoundSql的时候，复制additionalParameter

### DIFF
--- a/src/main/java/com/github/pagehelper/PageInterceptor.java
+++ b/src/main/java/com/github/pagehelper/PageInterceptor.java
@@ -51,6 +51,7 @@ import org.apache.ibatis.transaction.managed.ManagedTransactionFactory;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
 
@@ -183,6 +184,12 @@ public class PageInterceptor implements Interceptor {
         Configuration configuration = ms.getConfiguration();
         //异步不能复用 BoundSql，因为分页使用时会添加分页参数，这里需要复制一个新的
         BoundSql countBoundSql = new BoundSql(configuration, boundSql.getSql(), new ArrayList<>(boundSql.getParameterMappings()), parameter);
+        Map<String, Object> additionalParameter = ExecutorUtil.getAdditionalParameter(boundSql);
+        if (additionalParameter != null){
+            for (String key : additionalParameter.keySet()) {
+                countBoundSql.setAdditionalParameter(key, additionalParameter.get(key));
+            }
+        }
         //异步想要起作用需要新的数据库连接，需要独立的事务，创建新的Executor，因此异步查询只适合在独立查询中使用，如果混合增删改操作，不能开启异步
         Environment environment = configuration.getEnvironment();
         TransactionFactory transactionFactory = null;


### PR DESCRIPTION

countBoundSql没有赋值additionalParameters，导致
foreach之类得到的额外参数(产生临时的参数)，无法被复制到countBoundSql，然后在executeAutoCount中又取复制后的additionalParameters（此时这里的数据是空的）
![image](https://github.com/user-attachments/assets/70c3a630-d572-456a-8297-a3666b885578)

原复制BoundSql：
![image](https://github.com/user-attachments/assets/a1ef5fce-33b2-4a9e-b3b1-af5817a60351)

executeAutoCount：
![image](https://github.com/user-attachments/assets/1ac1f7ea-5f19-4af5-a57a-797fdf3b94a8)
