### PR TITLE
feat: 添加华为云 GaussDB 数据库分页支持feat: 添加华为云 GaussDB 数据库分页支持

### DIFF
--- a/src/main/java/com/github/pagehelper/dialect/helper/GaussDBDialect.java
+++ b/src/main/java/com/github/pagehelper/dialect/helper/GaussDBDialect.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2023 abel533@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.github.pagehelper.dialect.helper;
+
+import com.github.pagehelper.Page;
+import com.github.pagehelper.dialect.AbstractHelperDialect;
+import com.github.pagehelper.util.MetaObjectUtil;
+import org.apache.ibatis.cache.CacheKey;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.mapping.ParameterMapping;
+import org.apache.ibatis.reflection.MetaObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * GaussDB 方言
+ *
+ * @author nieqiurong
+ * @since 6.1.2
+ */
+public class GaussDBDialect extends AbstractHelperDialect {
+
+    @Override
+    public Object processPageParameter(MappedStatement ms, Map<String, Object> paramMap, Page page, BoundSql boundSql, CacheKey pageKey) {
+        paramMap.put(PAGEPARAMETER_FIRST, page.getStartRow());
+        paramMap.put(PAGEPARAMETER_SECOND, page.getPageSize());
+        pageKey.update(page.getStartRow());
+        pageKey.update(page.getPageSize());
+        if (boundSql.getParameterMappings() != null) {
+            List<ParameterMapping> newParameterMappings = new ArrayList<ParameterMapping>(boundSql.getParameterMappings());
+            if (page.getStartRow() == 0) {
+                newParameterMappings.add(new ParameterMapping.Builder(ms.getConfiguration(), PAGEPARAMETER_SECOND, int.class).build());
+            } else {
+                newParameterMappings.add(new ParameterMapping.Builder(ms.getConfiguration(), PAGEPARAMETER_FIRST, long.class).build());
+                newParameterMappings.add(new ParameterMapping.Builder(ms.getConfiguration(), PAGEPARAMETER_SECOND, int.class).build());
+            }
+            MetaObject metaObject = MetaObjectUtil.forObject(boundSql);
+            metaObject.setValue("parameterMappings", newParameterMappings);
+        }
+        return paramMap;
+    }
+
+    /**
+     * 构建 <a href="https://support.huaweicloud.com/centralized-devg-v8-gaussdb/gaussdb-42-1702.html">GaussDB</a>分页查询语句
+     */
+    @Override
+    public String getPageSql(String sql, Page page, CacheKey pageKey) {
+        StringBuilder sqlBuilder = new StringBuilder(sql.length() + 14);
+        sqlBuilder.append(sql);
+        if (page.getStartRow() == 0) {
+            sqlBuilder.append(" LIMIT ? ");
+        } else {
+            sqlBuilder.append(" LIMIT ?, ? ");
+        }
+        return sqlBuilder.toString();
+    }
+
+}

--- a/src/main/java/com/github/pagehelper/dialect/rowbounds/GaussDBRowBoundsDialect.java
+++ b/src/main/java/com/github/pagehelper/dialect/rowbounds/GaussDBRowBoundsDialect.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2023 abel533@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.github.pagehelper.dialect.rowbounds;
+
+import com.github.pagehelper.dialect.AbstractRowBoundsDialect;
+import org.apache.ibatis.cache.CacheKey;
+import org.apache.ibatis.session.RowBounds;
+
+/**
+ * GaussDB 基于 RowBounds 的分页.
+ *
+ * @author nieqiurong
+ * @since 6.1.2
+ */
+public class GaussDBRowBoundsDialect extends AbstractRowBoundsDialect {
+
+    /**
+     * 构建 <a href="https://support.huaweicloud.com/centralized-devg-v8-gaussdb/gaussdb-42-1702.html">GaussDB</a>分页查询语句
+     */
+    @Override
+    public String getPageSql(String sql, RowBounds rowBounds, CacheKey pageKey) {
+        StringBuilder sqlBuilder = new StringBuilder(sql.length() + 14);
+        sqlBuilder.append(sql);
+        if (rowBounds.getOffset() == 0) {
+            sqlBuilder.append(" LIMIT ");
+            sqlBuilder.append(rowBounds.getLimit());
+        } else {
+            sqlBuilder.append(" LIMIT ");
+            sqlBuilder.append(rowBounds.getOffset());
+            sqlBuilder.append(",");
+            sqlBuilder.append(rowBounds.getLimit());
+            pageKey.update(rowBounds.getOffset());
+        }
+        pageKey.update(rowBounds.getLimit());
+        return sqlBuilder.toString();
+    }
+
+}

--- a/src/main/java/com/github/pagehelper/page/PageAutoDialect.java
+++ b/src/main/java/com/github/pagehelper/page/PageAutoDialect.java
@@ -103,6 +103,7 @@ public class PageAutoDialect {
 
         //openGauss数据库
         registerDialectAlias("opengauss", PostgreSqlDialect.class);
+        registerDialectAlias("gaussdb", GaussDBDialect.class);
         registerDialectAlias("sundb", OracleDialect.class);
 
         //注册 AutoDialect


### PR DESCRIPTION
## 概述
添加华为云 GaussDB 数据库的分页支持。

## 变更内容
- 新增 `GaussDBDialect` 实现 GaussDB 分页方言
- 新增 `GaussDBRowBoundsDialect` 实现基于 RowBounds 的分页
- 在 `PageAutoDialect` 中注册 `gaussdb` 别名

## 技术实现
GaussDB 使用 `LIMIT offset, count` 语法（类似 MySQL）：
- 当 offset 为 0 时，使用 `LIMIT count` 简化语法
- 当 offset > 0 时，使用 `LIMIT offset, count`

参考文档：https://support.huaweicloud.com/centralized-devg-v8-gaussdb/gaussdb-42-1702.html

## 验证
- ✅ 代码编译通过 (`mvn clean compile`)
- ✅ 代码风格符合项目规范
- ✅ 与现有方言实现保持一致

## 相关 Issue/PR
- 基于 PR #861 by @nieqiurong
- 关闭 #860

## 测试建议
建议在实际 GaussDB 环境中进行集成测试，可参考测试工程：https://github.com/nieqiurong/gaussdb-pagehelper-demo

Co-authored-by: nieqiurong <nieqiuqiu@gmail.com>- 新增 GaussDBDialect 实现 GaussDB 分页方言
- 新增 GaussDBRowBoundsDialect 实现基于 RowBounds 的分页
- 在 PageAutoDialect 中注册 gaussdb 别名
- GaussDB 使用 LIMIT offset, count 语法

参考 PR #861